### PR TITLE
fix(android): automatically migrate to new cipher

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="appcelerator.encrypteddatabase" android:versionCode="1" android:versionName="1.0">
+	<uses-sdk android:minSdkVersion="14" />
+</manifest>

--- a/android/encrypteddatabase.iml
+++ b/android/encrypteddatabase.iml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="PROJECT_TYPE" value="1" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="sqlcipher" level="project" />
+    <orderEntry type="module" module-name="common" scope="PROVIDED" />
+    <orderEntry type="module" module-name="kroll-apt" scope="PROVIDED" />
+    <orderEntry type="module" module-name="titanium" scope="PROVIDED" />
+  </component>
+</module>

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.4
+version: 3.0.5
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: Provides transparent, secure 256-bit AES encryption of SQLite database files.


### PR DESCRIPTION
- Automatically migrate database if necessary using `cipher_migrate`.

[JIRA Ticket](https://jira.appcelerator.org/browse/MOD-2523)