### PR TITLE
fix(android): preserve field type

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.1.0
+version: 3.2.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: Provides transparent, secure 256-bit AES encryption of SQLite database files.


### PR DESCRIPTION
- Fixed bug where field types were always interpreted as strings

##### TEST CASE
```JS
const instance = require('appcelerator.encrypteddatabase').open('test.db');

instance.execute('CREATE TABLE IF NOT EXISTS testtable(id INTEGER PRIMARY KEY, name TEXT, age INTEGER)');
instance.execute(`INSERT OR REPLACE INTO testtable(id, name, age) VALUES (1, 'Chandan', 33)`);

const rowHandle = instance.execute('SELECT * FROM testtable WHERE id=1;');
if (rowHandle.isValidRow()) {
    var id = rowHandle.fieldByName('id') ;
    var name = rowHandle.fieldByName('name') ;
    var age = rowHandle.fieldByName('age') ;
}
rowHandle.close();

console.log('type of id=' + typeof(id));
console.log('type of name=' + typeof(name));
console.log('type of age=' + typeof(age));

instance.close();
```
```
type of id=number
type of name=string
type of age=number
```

[JIRA Ticket](https://jira.appcelerator.org/browse/MOD-2558)