### PR TITLE
Follow the docs repo rename to titaniumsdk.com

### DIFF
--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -48,7 +48,7 @@ jobs:
     # produce a failing run. The allowlist in titanium-www is the actual
     # boundary -- a fork's payload names the fork, which is not on it.
     if: github.event_name != 'pull_request' && github.repository_owner == 'tidev'
-    uses: tidev/titanium-www/.github/workflows/notify-api-docs.yml@main
+    uses: tidev/titaniumsdk.com/.github/workflows/notify-api-docs.yml@main
     secrets:
       dispatch-token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}
 


### PR DESCRIPTION
`tidev/titanium-www` has been renamed to `tidev/titaniumsdk.com`. This updates the reusable workflow reference to match.

GitHub redirects the old name, so **this is not fixing a break** — the `uses:` still resolves today. But pinning to a redirect is a dependency on a redirect, and the name in the file should say where the workflow actually lives.

The legacy `tidev/titanium-docs` dispatch is untouched.

### Unrelated: the dispatch token is dead

Worth knowing while you look at this. Both dispatch jobs currently fail with `Bad credentials`, including the legacy one that has been in these repos for years and points at `titanium-docs`. `REGEN_DOCS_GITHUB_TOKEN` has expired or been revoked — the last successful docs regen in any of the 17 repos was **2026-05-09**. That needs a new token and is not addressed here.